### PR TITLE
Add Get Command

### DIFF
--- a/src/bin/node_simulator/main.rs
+++ b/src/bin/node_simulator/main.rs
@@ -163,5 +163,18 @@ fn execute_command(
                 )))
             }
         },
+        simulation_commands::Commands::Get(get_args) => match &get_args.command {
+            simulation_commands::get_command::Commands::Node(get_node_event) => {
+                _ = node_event_tx.send(node::Event::Get(node::event::get::GetEvent::Node(
+                    get_node_event.into(),
+                )))
+            }
+            simulation_commands::get_command::Commands::Tps => {
+                _ = node_event_tx.send(node::Event::Get(node::event::get::GetEvent::Tps))
+            }
+            simulation_commands::get_command::Commands::Fps => {
+                _ = scene_event_tx.send(scene_event::Event::GetFps)
+            }
+        },
     }
 }

--- a/src/bin/node_simulator/simulation_commands.rs
+++ b/src/bin/node_simulator/simulation_commands.rs
@@ -1,4 +1,5 @@
 pub mod add_command;
+pub mod get_command;
 pub mod remove_command;
 pub mod set_command;
 
@@ -14,6 +15,7 @@ pub enum Commands {
     Add(add_command::AddCommand),
     Remove(remove_command::RemoveCommand),
     Set(set_command::SetCommand),
+    Get(get_command::GetCommand),
     ToggleScene,
     Close,
 }

--- a/src/bin/node_simulator/simulation_commands/get_command.rs
+++ b/src/bin/node_simulator/simulation_commands/get_command.rs
@@ -1,0 +1,17 @@
+pub mod node_args;
+
+use node_args::NodeArgs;
+
+#[derive(clap::Parser, Debug)]
+#[command(help_template = "Commands:\r\n{subcommands}")]
+pub struct GetCommand {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum Commands {
+    Node(NodeArgs),
+    Tps,
+    Fps,
+}

--- a/src/bin/node_simulator/simulation_commands/get_command/node_args.rs
+++ b/src/bin/node_simulator/simulation_commands/get_command/node_args.rs
@@ -1,0 +1,45 @@
+#[derive(clap::Args, Debug)]
+pub struct NodeArgs {
+    #[arg(long)]
+    pub id: u32,
+    #[arg(long)]
+    pub position: bool,
+    #[arg(long)]
+    pub velocity: bool,
+    #[arg(long)]
+    pub mass: bool,
+    #[arg(long)]
+    pub gravitational_constant_override: bool,
+    #[arg(long)]
+    pub dampen_rate: bool,
+    #[arg(long)]
+    pub freeze: bool,
+}
+
+impl From<NodeArgs> for node_simulator::node::event::get::NodeArgs {
+    fn from(value: NodeArgs) -> Self {
+        Self {
+            id: value.id,
+            position: value.position,
+            velocity: value.velocity,
+            mass: value.mass,
+            gravitational_constant_override: value.gravitational_constant_override,
+            dampen_rate: value.dampen_rate,
+            freeze: value.freeze,
+        }
+    }
+}
+
+impl From<&NodeArgs> for node_simulator::node::event::get::NodeArgs {
+    fn from(value: &NodeArgs) -> Self {
+        Self {
+            id: value.id,
+            position: value.position,
+            velocity: value.velocity,
+            mass: value.mass,
+            gravitational_constant_override: value.gravitational_constant_override,
+            dampen_rate: value.dampen_rate,
+            freeze: value.freeze,
+        }
+    }
+}

--- a/src/bin/node_simulator/simulation_commands/set_command/fps_args.rs
+++ b/src/bin/node_simulator/simulation_commands/set_command/fps_args.rs
@@ -2,7 +2,7 @@ use node_simulator::graphics::scene_event;
 
 #[derive(clap::Args, Debug)]
 pub struct FpsArgs {
-    pub target: Option<u32>,
+    pub target: u32,
 }
 
 impl From<&FpsArgs> for scene_event::SetTargetFpsEvent {

--- a/src/bin/node_simulator/simulation_commands/set_command/tps_args.rs
+++ b/src/bin/node_simulator/simulation_commands/set_command/tps_args.rs
@@ -2,7 +2,7 @@ use node_simulator::node;
 
 #[derive(clap::Args, Debug)]
 pub struct TpsArgs {
-    pub target: Option<u32>,
+    pub target: u32,
 }
 
 impl From<&TpsArgs> for node::SetTargetTpsEvent {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -209,12 +209,8 @@ impl GraphicsInterface {
             scene_event::Event::ToggleScene(_toggle_event) => {
                 self.toggle_state();
             }
-            scene_event::Event::SetTargetFps(target_fps_event) => {
-                match target_fps_event.target_fps {
-                    Some(target_fps) => self.set_target_fps(target_fps),
-                    None => println!("FPS - {}", self.target_fps),
-                }
-            }
+            scene_event::Event::SetTargetFps(event) => self.set_target_fps(event.target_fps),
+            scene_event::Event::GetFps => println!("fps: {}", self.target_fps),
         };
         EventStatus::Handled
     }

--- a/src/graphics/scene_event.rs
+++ b/src/graphics/scene_event.rs
@@ -2,6 +2,7 @@ pub enum Event {
     Close(CloseEvent),
     ToggleScene(ToggleSceneEvent),
     SetTargetFps(SetTargetFpsEvent),
+    GetFps,
 }
 
 pub struct CloseEvent {}
@@ -9,5 +10,5 @@ pub struct CloseEvent {}
 pub struct ToggleSceneEvent {}
 
 pub struct SetTargetFpsEvent {
-    pub target_fps: Option<u32>,
+    pub target_fps: u32,
 }

--- a/src/node/event.rs
+++ b/src/node/event.rs
@@ -1,9 +1,11 @@
 pub mod add_node;
+pub mod get;
 pub mod remove_node;
 pub mod set_node;
 pub mod set_target_tps;
 
 use add_node::AddNodeEvent;
+use get::GetEvent;
 use remove_node::RemoveNodeEvent;
 use set_node::SetNodeEvent;
 use set_target_tps::SetTargetTpsEvent;
@@ -12,5 +14,6 @@ pub enum Event {
     AddNode(AddNodeEvent),
     RemoveNode(RemoveNodeEvent),
     SetNode(SetNodeEvent),
+    Get(GetEvent),
     SetTargetTps(SetTargetTpsEvent),
 }

--- a/src/node/event/get.rs
+++ b/src/node/event/get.rs
@@ -1,0 +1,104 @@
+use crate::{
+    node::{self, Node},
+    simulation::Simulation,
+};
+
+pub enum GetEvent {
+    Node(NodeArgs),
+    Tps,
+}
+
+pub struct NodeArgs {
+    pub id: u32,
+    pub position: bool,
+    pub velocity: bool,
+    pub mass: bool,
+    pub gravitational_constant_override: bool,
+    pub dampen_rate: bool,
+    pub freeze: bool,
+}
+
+impl GetEvent {
+    pub fn handle(&self, simulation: &Simulation) {
+        match self {
+            GetEvent::Node(node_args) => node_args.display_node_information(simulation),
+            GetEvent::Tps => println!("tps: {}", simulation.target_tps()),
+        }
+    }
+}
+
+impl NodeArgs {
+    pub fn display_node_information(&self, simulation: &Simulation) {
+        let node = match simulation
+            .nodes
+            .iter()
+            .find(|node| node.id == node::Id(self.id))
+        {
+            Some(node) => node,
+            None => {
+                println!("Error displaying node information for node with id {} - no node with that id exists", self.id);
+                return;
+            }
+        };
+
+        println!("{}", self.get_display_string_from_node_args(node));
+    }
+
+    fn get_display_string_from_node_args(&self, node: &Node) -> String {
+        let mut display_string = format!("Node {}:", node.id.to_string());
+        // TODO - Use bitflags crate - https://docs.rs/bitflags/latest/bitflags/
+        let no_flags_present = !(self.position
+            || self.velocity
+            || self.mass
+            || self.gravitational_constant_override
+            || self.dampen_rate
+            || self.freeze);
+
+        display_string = match self.position || no_flags_present {
+            true => format!(
+                "{display_string}\n\tposition: {}",
+                node.position.to_string()
+            ),
+            false => display_string,
+        };
+
+        display_string = match self.velocity || no_flags_present {
+            true => format!(
+                "{display_string}\n\tvelocity: {}",
+                node.velocity.to_string()
+            ),
+            false => display_string,
+        };
+
+        display_string = match self.mass || no_flags_present {
+            true => format!("{display_string}\n\tmass: {}", node.mass.to_string()),
+            false => display_string,
+        };
+
+        display_string = match self.gravitational_constant_override || no_flags_present {
+            true => {
+                let value = match node.gravitational_constant_override {
+                    Some(value) => value.to_string(),
+                    None => "None".to_string(),
+                };
+                format!("{display_string}\n\tgravitational constant override: {value}")
+            }
+            false => display_string,
+        };
+
+        display_string = match self.dampen_rate || no_flags_present {
+            true => format!(
+                "{display_string}\n\tdampen rate: {}",
+                node.dampen_rate.to_string()
+            ),
+            false => display_string,
+        };
+
+        display_string = match self.freeze || no_flags_present {
+            true => format!("{display_string}\n\tfreeze: {}", node.freeze.to_string()),
+            false => display_string,
+        };
+
+        display_string
+    }
+}

--- a/src/node/event/set_target_tps.rs
+++ b/src/node/event/set_target_tps.rs
@@ -1,3 +1,3 @@
 pub struct SetTargetTpsEvent {
-    pub target_tps: Option<u32>,
+    pub target_tps: u32,
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -46,10 +46,7 @@ impl<'a> Simulation {
                 self.remove_node(remove_node_event.node_id)
             }
             node::Event::SetTargetTps(set_target_tps_event) => {
-                match set_target_tps_event.target_tps {
-                    Some(target_tps) => self.set_target_tps(target_tps),
-                    None => println!("TPS - {}", self.target_tps),
-                }
+                self.set_target_tps(set_target_tps_event.target_tps)
             }
             node::Event::SetNode(set_node_event) => {
                 let node: &mut node::Node = match self
@@ -96,6 +93,7 @@ impl<'a> Simulation {
                     None => {}
                 };
             }
+            node::Event::Get(get_event) => get_event.handle(self),
         }
     }
 


### PR DESCRIPTION
# Summary of changes
- Adds `get` command with `tps`, `fps`, and `node` subcommands
- Set fps and set tps now require an argument - before, no argument would print the pre-existing values. This is now handled via the `get` command