### PR TITLE
Replace tarpaulin with llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,28 +11,21 @@ on:
       - 'develop'
   workflow_dispatch:
 jobs:
-  test:
-    name: Coverage
+  coverage:
     runs-on: ubuntu-latest
-    container:
-      image: xd009642/tarpaulin:develop-nightly
-      options: --security-opt seccomp=unconfined
+    env:
+      CARGO_TERM_COLOR: always
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install CMake
-        uses: symbitic/install-cmake@master
-
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: |
-          cargo +nightly tarpaulin --verbose --no-default-features --config tarpaulin_no_wgpu.toml --timeout 120 --out html --out xml --output-dir "tarpaulin_output" -- --test-threads 1
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report
-          path: tarpaulin_output/tarpaulin-report.html
-      - name: Upload coverage reports to Codecov
+        run: cargo llvm-cov --no-default-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+    

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,5 +1,0 @@
-[no_wgpu_coverage]
-features = ""
-
-[wgpu_coverage]
-features = "wgpu"

--- a/tarpaulin_no_wgpu.toml
+++ b/tarpaulin_no_wgpu.toml
@@ -1,4 +1,0 @@
-# wgpu is a default feature - make sure you run with --no-default-features
-
-[no_wgpu_coverage]
-features = ""


### PR DESCRIPTION
Replaces our use of [tarpaulin](https://github.com/xd009642/tarpaulin) with [llvm-cov](https://github.com/taiki-e/cargo-llvm-cov).