### PR TITLE
Add integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,6 @@ glob = "0.3"
 [dev-dependencies]
 utils = {path = "utils" }
 rstest = "0.18"
+test_bin = "0.4"
 
 

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -1,0 +1,75 @@
+mod common;
+
+const EXPECTED_HELP_COMMAND_OUTPUT: &str = r"Running node_simulator...
+Commands:
+  add           
+  remove        
+  set           
+  get           
+  toggle-scene  
+  close         
+  help          Print this message or the help of the given subcommand(s)
+
+";
+
+const EXPECTED_ADD_NODE_COMMAND_OUTPUT: &str = r#"Running node_simulator...
+Node 1:
+	position: x: 1, y: 2, z: 3
+"#;
+
+const EXPECTED_REMOVE_NODE_COMMAND_OUTPUT: &str = r#"Running node_simulator...
+Error displaying node information for node with id 1 - no node with that id exists
+"#;
+
+#[test]
+fn can_execute_help_command() {
+    let mut process = common::Binary::get();
+    let std_in = process.stdin.take().expect("Child had no stdin");
+    let std_out = process.stdout.take().expect("Child had no stdout");
+
+    common::Write::write_line_to_cli(std_in, "--help");
+    let output = common::Read::read_from_cli(std_out);
+
+    assert_eq!(EXPECTED_HELP_COMMAND_OUTPUT, output);
+
+    common::Binary::kill(process);
+}
+
+#[test]
+fn can_execute_add_node_command() {
+    let mut process = common::Binary::get();
+    let std_in = process.stdin.take().expect("Child had no stdin");
+    let std_out = process.stdout.take().expect("Child had no stdout");
+
+    let commands = vec![
+        "add node --id 1 --position 1,2,3",
+        "get node --id 1 --position",
+    ];
+
+    common::Write::write_lines_to_cli(std_in, commands.iter());
+    let output = common::Read::read_from_cli(std_out);
+
+    assert_eq!(EXPECTED_ADD_NODE_COMMAND_OUTPUT, output);
+
+    common::Binary::kill(process);
+}
+
+#[test]
+fn can_execute_remove_node_command() {
+    let mut process = common::Binary::get();
+    let std_in = process.stdin.take().expect("Child had no stdin");
+    let std_out = process.stdout.take().expect("Child had no stdout");
+
+    let commands = vec![
+        "add node --id 1 --position 1,2,3",
+        "remove node --id 1",
+        "get node --id 1 --position",
+    ];
+
+    common::Write::write_lines_to_cli(std_in, commands.iter());
+    let output = common::Read::read_from_cli(std_out);
+
+    assert_eq!(EXPECTED_REMOVE_NODE_COMMAND_OUTPUT, output);
+
+    common::Binary::kill(process);
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,66 @@
+use std::{
+    io::{BufRead, BufReader},
+    process::{Child, ChildStdin, ChildStdout, Stdio},
+    slice::Iter,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+pub struct Binary {}
+
+impl Binary {
+    pub fn get() -> std::process::Child {
+        test_bin::get_test_bin("node_simulator")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap()
+    }
+
+    pub fn kill(mut process: Child) {
+        process.kill().unwrap();
+    }
+}
+
+pub struct Write {}
+
+impl Write {
+    pub fn write_lines_to_cli(mut std_in: ChildStdin, lines: Iter<&str>) {
+        for line in lines {
+            let line = format! {"{line}\n"};
+            std::io::Write::write_all(&mut std_in, line.as_bytes()).unwrap();
+        }
+    }
+
+    pub fn write_line_to_cli(std_in: ChildStdin, line: &str) {
+        Self::write_lines_to_cli(std_in, vec![line].iter());
+    }
+}
+
+pub struct Read {}
+
+impl Read {
+    pub fn read_from_cli(std_out: ChildStdout) -> String {
+        let (tx, rx) = mpsc::channel();
+        let mut output_string = String::new();
+        let mut std_out_buffer = BufReader::new(std_out);
+
+        thread::spawn(move || {
+            while std_out_buffer
+                .read_line(&mut output_string)
+                .expect("Error reading from child output")
+                != 0
+            {
+                tx.send(output_string.clone()).unwrap();
+                output_string.clear();
+            }
+        });
+        thread::sleep(Duration::new(1, 0));
+        let mut output = String::new();
+        while let Ok(result) = rx.try_recv() {
+            output.push_str(&result);
+        }
+        output
+    }
+}


### PR DESCRIPTION
# Summary of changes
- Adds integration tests for the `help`, `add`, `remove`, and `get` commands
- Fixes a crash when setting the `tps` property to 0