### PR TITLE
Add step command

### DIFF
--- a/src/bin/node_simulator/main.rs
+++ b/src/bin/node_simulator/main.rs
@@ -185,5 +185,8 @@ fn execute_command(
                 _ = scene_event_tx.send(scene_event::Event::GetFps)
             }
         },
+        simulation_commands::Commands::Step(step_args) => {
+            _ = node_event_tx.send(node::Event::Step(step_args.into()))
+        }
     }
 }

--- a/src/bin/node_simulator/simulation_commands.rs
+++ b/src/bin/node_simulator/simulation_commands.rs
@@ -2,6 +2,7 @@ pub mod add_command;
 pub mod get_command;
 pub mod remove_command;
 pub mod set_command;
+pub mod step_command;
 
 #[derive(clap::Parser, Debug)]
 #[command(help_template = "Commands:\r\n{subcommands}")]
@@ -18,6 +19,7 @@ pub enum Commands {
     Get(get_command::GetCommand),
     ToggleScene,
     Close,
+    Step(step_command::StepCommand),
 }
 
 impl SimulationCommands {

--- a/src/bin/node_simulator/simulation_commands/step_command.rs
+++ b/src/bin/node_simulator/simulation_commands/step_command.rs
@@ -1,0 +1,15 @@
+use node_simulator::node;
+
+#[derive(clap::Args, Debug)]
+pub struct StepCommand {
+    #[arg(default_value = "1")]
+    pub number_of_steps: u32,
+}
+
+impl From<&StepCommand> for node::event::step::StepEvent {
+    fn from(value: &StepCommand) -> Self {
+        Self {
+            steps: value.number_of_steps,
+        }
+    }
+}

--- a/src/node/event.rs
+++ b/src/node/event.rs
@@ -3,12 +3,14 @@ pub mod get;
 pub mod remove_node;
 pub mod set_node;
 pub mod set_target_tps;
+pub mod step;
 
 use add_node::AddNodeEvent;
 use get::GetEvent;
 use remove_node::RemoveNodeEvent;
 use set_node::SetNodeEvent;
 use set_target_tps::SetTargetTpsEvent;
+use step::StepEvent;
 
 pub enum Event {
     AddNode(AddNodeEvent),
@@ -16,4 +18,5 @@ pub enum Event {
     SetNode(SetNodeEvent),
     Get(GetEvent),
     SetTargetTps(SetTargetTpsEvent),
+    Step(StepEvent),
 }

--- a/src/node/event/step.rs
+++ b/src/node/event/step.rs
@@ -1,0 +1,3 @@
+pub struct StepEvent {
+    pub steps: u32,
+}

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -1,6 +1,6 @@
 mod common;
 
-const EXPECTED_HELP_COMMAND_OUTPUT: &str = r"Running node_simulator...
+const EXPECTED_HELP_COMMAND_OUTPUT: &str = r#"Running node_simulator...
 Commands:
   add           
   remove        
@@ -8,9 +8,10 @@ Commands:
   get           
   toggle-scene  
   close         
+  step          
   help          Print this message or the help of the given subcommand(s)
 
-";
+"#;
 
 const EXPECTED_ADD_NODE_COMMAND_OUTPUT: &str = r#"Running node_simulator...
 Node 1:


### PR DESCRIPTION
Adds `step` command, allowing for stepping through the simulation.

Syntax: `step <number of steps>`. Number of steps defaults to 1.