### PR TITLE
Fix up integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run Tests
-      run: cargo test --verbose --no-default-features -- --test-threads 1
+      run: cargo test --verbose --no-default-features

--- a/src/bin/node_simulator/main.rs
+++ b/src/bin/node_simulator/main.rs
@@ -100,6 +100,9 @@ fn read_input_from_cli(
         io::stdin()
             .read_line(&mut input)
             .expect("Failed to read input");
+        if input.is_empty() {
+            continue;
+        }
 
         let command = SimulationCommand::try_from(input);
         match command {

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -9,6 +9,7 @@ Commands:
   toggle-scene  
   close         
   step          
+  script        
   help          Print this message or the help of the given subcommand(s)
 
 "#;

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -22,7 +22,7 @@ const EXPECTED_REMOVE_NODE_COMMAND_OUTPUT: &str = r#"Running node_simulator...
 Error displaying node information for node with id 1 - no node with that id exists
 "#;
 
-//#[test]
+#[test]
 fn can_execute_help_command() {
     let mut process = common::Binary::get();
     let std_in = process.stdin.take().expect("Child had no stdin");
@@ -36,7 +36,7 @@ fn can_execute_help_command() {
     common::Binary::kill(process);
 }
 
-//#[test]
+#[test]
 fn can_execute_add_node_command() {
     let mut process = common::Binary::get();
     let std_in = process.stdin.take().expect("Child had no stdin");
@@ -55,7 +55,7 @@ fn can_execute_add_node_command() {
     common::Binary::kill(process);
 }
 
-//#[test]
+#[test]
 fn can_execute_remove_node_command() {
     let mut process = common::Binary::get();
     let std_in = process.stdin.take().expect("Child had no stdin");


### PR DESCRIPTION
Fixes up our integration tests, caused by a8cac637d8e29932422e2d0ae98b8e075091f710.
Also updates the help command integration test following the addition of the `script` command, and re-enables parallel tests in the pipeline.

Closes #25 and #36.